### PR TITLE
FIX - 주소창으로 twitter에 접속하면 확장이 연결되지 않는 문제

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,7 @@
 	},
 	"content_scripts": [
 		{
-			"matches": ["https://twitter.com/*/status/*"],
+			"matches": ["https://twitter.com/*"],
 			"js": ["src/content.ts"]
 		}
 	],


### PR DESCRIPTION
메니페스트의 match 주소가 http://twitter.com/*/status/*" 였던 것이 문제 (아마 SPA 성질 상 브라우저가 보는 url은 바뀌지 않아서?)(확인 필요)
twitter.com을 시작점으로 트위터에 접속하면 match url과 불일치하고
프로필이나 트윗에서 새로고침하면 url과 match했던 것으로 추정

[이유는 벨로그에 정리](https://velog.io/@limgs/%ED%99%95%EC%9E%A5-%EA%B0%9C%EB%B0%9C-%EC%A4%91-%EC%97%90%EB%9F%AC-SPA%EC%99%80-content-script)
---
설계가 변경되어 이 브랜치에서 더 수정할 내용은 없어졌음