### PR TITLE
Feat/button

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,12 @@
 		}
 	],
 
-	"permissions": ["activeTab", "downloads", "scripting", "tabs"],
+	"permissions": [
+		"activeTab",
+		"downloads",
+		"scripting",
+		"tabs",
+		"webNavigation"
+	],
 	"host_permissions": ["https://twitter.com/*"]
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -86,6 +86,24 @@ function startObserve(): void {
 				)?.firstElementChild;
 				console.log("variable init");
 
+				const addDownBtn = (tweet: HTMLElement) => {
+					const btn = document.createElement("button");
+					btn.textContent = "Down";
+					const newBtn = btn.cloneNode(true);
+					newBtn.addEventListener("click", () => {
+						chrome.runtime.sendMessage({
+							message: "Download Button Click",
+							author: getAuthor(tweet),
+							date: getDate(tweet),
+							src: getImgSrc(tweet),
+						});
+						console.log(getAuthor(tweet), getDate(tweet), getImgSrc(tweet));
+					});
+
+					const imageAera = tweet.querySelector(".css-1dbjc4n.r-580adz");
+					imageAera?.appendChild(newBtn);
+				};
+
 				const observer = new MutationObserver((mutationRecord) => {
 					for (let record of mutationRecord) {
 						//record.addedNodes[0]의 타입은 Node라서 querySelector에 경고 발생
@@ -122,6 +140,10 @@ function startObserve(): void {
 				//container 안의 트윗의 변화를 감지
 				observer.observe(tlSnd, { childList: true });
 				console.log("start observe");
+				console.log(tlSnd?.children);
+				for (let tweet of tlSnd!.children) {
+					addDownBtn(tweet as HTMLElement);
+				}
 			}, 1000 * 1);
 		}
 	}, 100);

--- a/src/service.ts
+++ b/src/service.ts
@@ -8,6 +8,13 @@ chrome.commands.onCommand.addListener((command) => {
 	}
 });
 
+chrome.webNavigation.onHistoryStateUpdated.addListener(() => {
+	chrome.tabs.query({ currentWindow: true, active: true }, (result) => {
+		const currentTabID = result[0].id as number;
+		chrome.tabs.sendMessage(currentTabID, "history updated");
+	});
+});
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 	if (message.message === "Download Button Click") {
 		//chrome.downloads.download();

--- a/src/service.ts
+++ b/src/service.ts
@@ -8,11 +8,13 @@ chrome.commands.onCommand.addListener((command) => {
 	}
 });
 
-chrome.webNavigation.onHistoryStateUpdated.addListener(() => {
-	chrome.tabs.query({ currentWindow: true, active: true }, (result) => {
-		const currentTabID = result[0].id as number;
-		chrome.tabs.sendMessage(currentTabID, "history updated");
-	});
+chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
+	if (details.url.startsWith("https://twitter.com")) {
+		chrome.tabs.query({ currentWindow: true, active: true }, (result) => {
+			const currentTabID = result[0].id as number;
+			chrome.tabs.sendMessage(currentTabID, "history updated");
+		});
+	}
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {


### PR DESCRIPTION
## 추가사항
- 트윗 이미지 위에 다운로드 버튼 띄우는 기능
MutationObserver API를 이용, 타임라인을 체크해 트윗 요소 생성시 트윗 이미지 위에 다운로드 버튼 삽입
- 타임라인이 갱신되어도 Observer 재삽입 기능
트위터 내 페이지 이동 등으로 인해 Observer가 체크하던 타임라인이 새로 만들어져도 history update event 마다 다시 Observer를 생성하는 기능